### PR TITLE
Fix Docker configuration and container networking

### DIFF
--- a/DOCKER_FIX.md
+++ b/DOCKER_FIX.md
@@ -1,0 +1,31 @@
+# Docker Compose Fix - Container Conflict & Prisma OpenSSL Error
+
+## Problem
+`docker-compose up --build` failed with:
+1. Container name conflict: `/grok-sdr-db` already exists
+2. Prisma crash: Missing OpenSSL in Alpine Linux
+
+## Fix
+
+### Step 1: Remove existing container
+```bash
+docker stop grok-sdr-db && docker rm grok-sdr-db
+```
+
+### Step 2: Update `backend/Dockerfile`
+Add this line after `FROM node:18-alpine`:
+```dockerfile
+RUN apk add --no-cache openssl libc6-compat
+```
+
+### Step 3: Rebuild
+```bash
+docker-compose up --build
+```
+
+## Explanation
+Alpine Linux is minimal and doesn't include OpenSSL. Prisma needs OpenSSL to connect to PostgreSQL. The packages:
+- `openssl`: SSL/TLS libraries for database connections
+- `libc6-compat`: Compatibility layer for Node.js native modules on Alpine
+
+This fixes the `Prisma failed to detect the libssl/openssl version` error.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:18-alpine
 
+# Install OpenSSL and other dependencies for Prisma
+RUN apk add --no-cache openssl libc6-compat
+
 WORKDIR /app
 
 COPY package*.json ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,9 +43,9 @@ services:
       dockerfile: Dockerfile
     container_name: grok-sdr-frontend
     ports:
-      - "3000:3000"
+      - "3000:5173"
     environment:
-      NEXT_PUBLIC_API_URL: http://localhost:3001
+      NEXT_PUBLIC_API_URL: http://backend:3001
     depends_on:
       - backend
     volumes:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,6 +7,6 @@ RUN npm install
 
 COPY . .
 
-EXPOSE 3000
+EXPOSE 5173
 
 CMD ["npm", "run", "dev"]

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -2,10 +2,11 @@
 const nextConfig = {
   reactStrictMode: true,
   async rewrites() {
+    // Use backend service name for server-side requests inside Docker
     return [
       {
         source: '/api/:path*',
-        destination: 'http://localhost:3001/api/:path*',
+        destination: 'http://backend:3001/api/:path*',
       },
     ];
   },


### PR DESCRIPTION
- Fixed port mapping: Frontend runs on 5173 internally, mapped to 3000 externally
- Updated container networking: Frontend now uses 'backend:3001' for internal API calls
- Added OpenSSL dependencies to backend Dockerfile for Prisma compatibility
- Fixed Next.js proxy configuration to properly route API requests between containers
- Added DOCKER_FIX.md documentation for troubleshooting

These changes resolve connection issues between frontend and backend containers and ensure proper API communication within the Docker network.