### PR TITLE
Fix Docker port configuration for frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       dockerfile: Dockerfile
     container_name: grok-sdr-frontend
     ports:
-      - "3000:5173"
+      - "3000:3000"
     environment:
       NEXT_PUBLIC_API_URL: http://backend:3001
     depends_on:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 5173",
+    "dev": "next dev",
     "build": "next build",
-    "start": "next start -p 5173"
+    "start": "next start"
   },
   "dependencies": {
     "@types/lodash": "^4.17.20",


### PR DESCRIPTION
- Updated frontend package.json to use default Next.js port 3000
- Fixed docker-compose.yml port mapping from 3000:5173 to 3000:3000
- Frontend now correctly runs on port 3000 both inside container and on host